### PR TITLE
Fix bug with incorrect "DKIM-Signature" header.

### DIFF
--- a/dkim.go
+++ b/dkim.go
@@ -128,6 +128,8 @@ const (
 	SetOpt Op = 1
 )
 
+const SignatureInitialPadding = 16
+
 // Lib is a dkim library handle
 type Lib struct {
 	lib *C.DKIM_LIB
@@ -328,7 +330,7 @@ func (d *Dkim) GetSigHdr(buf []byte) ([]byte, Status) {
 	if buf == nil {
 		buf = make([]byte, 1024)
 	}
-	stat := Status(C.dkim_getsighdr(d.dkim, (*C.u_char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), C.size_t(0)))
+	stat := Status(C.dkim_getsighdr(d.dkim, (*C.u_char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), SignatureInitialPadding))
 	if stat != StatusOK {
 		return nil, stat
 	}


### PR DESCRIPTION
First line of DKIM-Signature header is longer than 80 chars and MAY be splitted on transmitton of the email.
Example
This header

```
DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=mitimco.mit.edu; s=2018052117564801;
	t=1580750033; bh=Z9wNGgnyUB+Jbc+IX1dhlPLB/3LJW1Nyyi9edklgoZA=;
	h=Date:From:To:Subject;
	b=ilaRWSYXTgf57e2IhepHjzelpk+zxl0QQJFOH58XQCa0mXUAe5rsYu2uRoJtCR6BP
	 JaAqZN5AOlYRD6G2iSvqKCV96qzEccjx04cIN324ZwvbR0x46Ji2jr46irGLDgkOml
	 1iUHVmqn4HisjM10JmqjXFXHwlsCQVOX8WEm2Mzw=
```
MAY become

```
DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=mitimco.mit.edu;
s=2018052117564801;
	t=1580750033; bh=Z9wNGgnyUB+Jbc+IX1dhlPLB/3LJW1Nyyi9edklgoZA=;
	h=Date:From:To:Subject;
	b=ilaRWSYXTgf57e2IhepHjzelpk+zxl0QQJFOH58XQCa0mXUAe5rsYu2uRoJtCR6BP
	 JaAqZN5AOlYRD6G2iSvqKCV96qzEccjx04cIN324ZwvbR0x46Ji2jr46irGLDgkOml
	 1iUHVmqn4HisjM10JmqjXFXHwlsCQVOX8WEm2Mzw=
```
And it will brake format of multiline header.
Reason is a wrong padding value for first line of DKIM-Signature header for OpenDKIM library, [documentation](http://opendkim.org/libopendkim/dkim_getsighdr.html): 

> If for example, you want to have your headers wrapped at 75 bytes and the header to be added will be called "DKIM-Signature", the initial value should be 16 (length of the header's name plus room for a colon and a space). The default margin is 75; see dkim_set_margin().

This PR fix it by adding special constant that used as initial value.